### PR TITLE
Socket is a reserved classname

### DIFF
--- a/appendices/migration80/incompatible.xml
+++ b/appendices/migration80/incompatible.xml
@@ -1305,6 +1305,11 @@ $array["key"];
      <function>socket_addrinfo_lookup</function> have been removed.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     The <classname>Socket</classname> classname can no longer be used for custom classes.
+    </para>
+   </listitem>
   </itemizedlist>
  </sect2>
 


### PR DESCRIPTION
The fact that this classname can no longer be used for custom classes (making legacy code crash) is not explicitly stated anywhere.